### PR TITLE
Add wildfly maven plugin. Can be run with: mvn wildfly:run.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,11 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>1.0.2.Final</version>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Hello.

I have added the wildfly maven plugin in order to run it from maven with:

`````
mvn wildfly:run
`````

Please merge if you think it's ok and useful.

Cheers.

Edu.